### PR TITLE
Make the SSL_shutdown() hack actually work

### DIFF
--- a/Ref6a_advanced_bufferevents.txt
+++ b/Ref6a_advanced_bufferevents.txt
@@ -482,10 +482,18 @@ cache once closed. The following code implements this workaround.
 --------
 SSL *ctx = bufferevent_openssl_get_ssl(bev);
 
-/* SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN tells SSL_shutdown to
- * act as if the SSL close handshake had already been completed.
- * It is a nasty hack, but if we don't do it, SSL_shutdown will block. */
-SSL_set_shutdown(ctx, SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
+/*
+ * SSL_RECEIVED_SHUTDOWN tells SSL_shutdown to act as if we had already
+ * received a close notify from the other end.  SSL_shutdown will then
+ * send the final close notify in reply.  The other end will receive the
+ * close notify and send theirs.  By this time, we will have already
+ * closed the socket and the other end's real close notify will never be
+ * received.  In effect, both sides will think that they have completed a
+ * clean shutdown and keep their sessions valid.  This strategy will fail
+ * if the socket is not ready for writing, in which case this hack will
+ * lead to an unclean shutdown and lost session on the other end.
+ */
+SSL_set_shutdown(ctx, SSL_RECEIVED_SHUTDOWN);
 SSL_shutdown(ctx);
 bufferevent_free(bev);
 --------


### PR DESCRIPTION
The proposed hack does not achieve the goal, because it will lead to
an unclean shutdown on the other end, which means that the other end
will mark the session unclean and drop it from the session cache,
leading to degraded performance exactly as if we just closed the
socket.

So instead of setting both SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN,
only set SSL_RECEIVED_SHUTDOWN and let OpenSSL send a close notify.
Because there is no distinction in the protocol between close notify
requests and close notify replies, this has the net effect of a clean
shutdown on both ends of the SSL connection.

Also note that SSL_shutdown() will not block on a non-blocking socket.
Instead of blocking, it will return -1 with one of SSL_ERROR_WANT_READ
or SSL_ERROR_WANT_WRITE, telling us to retry SSL_shutdown() after the
underlying socket has become readable or writable, respectively.
