### PR TITLE
Don't contradict referencing sentence in footnote

### DIFF
--- a/01_intro.txt
+++ b/01_intro.txt
@@ -210,11 +210,11 @@ But we're still not done.  Because generating and reading the select()
 bit arrays takes time proportional to the largest fd that you provided
 for select(), the select() call scales terribly when the number of
 sockets is high.  footnote:[On the userspace side, generating and
-reading the bit arrays takes time proportional to the number of fds
-that you provided for select().  But on the kernel side, reading the
-bit arrays takes time proportional to the largest fd in the bit array,
-which tends to be around _the total number of fds in use in the whole
-program_, regardless of how many fds are added to the sets in
+reading the bit arrays can be made to take time proportional to the
+number of fds that you provided for select().  But on the kernel side,
+reading the bit arrays takes time proportional to the largest fd in the
+bit array, which tends to be around _the total number of fds in use in
+the whole program_, regardless of how many fds are added to the sets in
 select().]
 
 Different operating systems have provided different replacement


### PR DESCRIPTION
The footnote claiming that reading the fd_set takes time proportional to
the number of fds is confusing, since both the sentence referencing that
footnote and the example right above that sentence are saying that the
time is proportional to the largest fd.

Of course it's possible to do better by storing the fds separately, but
the footnote should not imply that this was done here.
